### PR TITLE
Fix broken #ifs

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -32,7 +32,7 @@ export class Helper {
    * @param {string} str String to check
    */
   static isFunction(str: string): boolean {
-    const re = /\{\{\s*#([^\s]+)(\s+([^\s]+))?\s*\}\}/g;
+    const re = /\{\{\s*#([^\s]+)(\s+([^\s]+))*\s*\}\}/g;
     return re.test(str);
   }
   /**


### PR DESCRIPTION
`isFunction` was only allowing 0 or 1 items after the `#func`, breaking all `if`s (obviously `#if typeof this === "string"`, for instance, has more than one token)