### PR TITLE
Allow for transforming object keys

### DIFF
--- a/__tests__/sunny/basic-sync/key-transform.test.js
+++ b/__tests__/sunny/basic-sync/key-transform.test.js
@@ -1,0 +1,10 @@
+const ST = require('../../../dist')['SelectTransform'];
+const allData = require('../common/key-transform.common');
+
+const st = new ST();
+
+test('transform is correct', done => {
+  const result = st.transformSync(allData.generalTemplate, allData.generalData);
+  expect(result).toEqual(allData.generalExpected);
+  done();
+});

--- a/__tests__/sunny/basic/key-transform.test.js
+++ b/__tests__/sunny/basic/key-transform.test.js
@@ -1,0 +1,11 @@
+const ST = require('../../../dist')['SelectTransform'];
+const allData = require('../common/key-transform.common');
+
+const st = new ST();
+
+test('transform is correct', done => {
+  st.transform(allData.generalTemplate, allData.generalData).then(result => {
+    expect(result).toEqual(allData.generalExpected);
+    done();
+  });
+});

--- a/__tests__/sunny/common/key-transform.common.js
+++ b/__tests__/sunny/common/key-transform.common.js
@@ -1,0 +1,23 @@
+module.exports = {
+  generalData: {
+    name: 'Jakub',
+    surname: 'Mifek',
+    age: 24,
+    car: 'sedan',
+  },
+
+  generalTemplate: {
+    name: '{{ name }}',
+    surname: '{{ surname }}',
+    age: '{{ age }}',
+    '{{ "the-car-of-" + name }}': '{{ car }}',
+  },
+
+  generalExpected: {
+    name: 'Jakub',
+    surname: 'Mifek',
+    age: 24,
+    'the-car-of-Jakub': 'sedan',
+  },
+
+};


### PR DESCRIPTION
Fixes #9 

I could find this sort of thing useful in my current project, which is a REST API. Basically, the input data maps an internal key name for something into the external key, and this library transforms that into a json schema validating what the user sends us. This way, I can change the key name in what the user is sending without having to update every single reference to it in my program. (very tedious 😉)

Example:

```javascript
let data = {
    "internalPropertyName": "externalPropertyName",
};

let schemaTemplate = {
    "properties": {
        "{{ internalPropertyName }}": {
            "type": "string"
        }
    }
};

let schema = st.transformSync(schemaTemplate , data);

// in a million different places in my program
let externalName = data.internalPropertyName;
doSomething( jsonFromUser[externalName] ); // don't have to update this if I change the external name!
```

P.S. should I commit the st.js browserify makes?